### PR TITLE
Amend term id

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -48,7 +48,7 @@ def scrape_mp(url)
     area: cell.(96),
     statut: cell.(97),
     image: noko.css('#cbfv_29 img/@src').text,
-    term: 6,
+    term: 7,
     source: url
   }
   puts "#{data[:id]} -> #{data[:faction]} = #{data[:faction_id]}"


### PR DESCRIPTION
The current term is the 7th. It had been mistakenly mislabeled as the 6th. 

This commit changes the hardcoded term id from 6 to 7 to reflect that the scraped term is the 7th.